### PR TITLE
chore: added test for SBOM's advisory 'scores'

### DIFF
--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -1126,6 +1126,9 @@ async fn get_advisories(ctx: &TrustifyContext) -> Result<(), anyhow::Error> {
     // assert expected fields
     assert_eq!(v[0]["identifier"], "https://www.redhat.com/#CVE-2023-0044");
     assert_eq!(v[0]["status"][0]["average_severity"], "medium");
+    assert_eq!(v[0]["status"][0]["scores"][0]["type"], "3.1");
+    assert_eq!(v[0]["status"][0]["scores"][0]["value"], 5.3);
+    assert_eq!(v[0]["status"][0]["scores"][0]["severity"], "medium");
 
     Ok(())
 }


### PR DESCRIPTION
I've just added some tests to check for the content of the new `scores` array